### PR TITLE
fix(error):将addEventListener('error')和onerror合并

### DIFF
--- a/femonitor-sdk/src/error/index.js
+++ b/femonitor-sdk/src/error/index.js
@@ -34,24 +34,36 @@ export default function error () {
           paths: e.path.map((item) => item.tagName).filter(Boolean),
           pageURL: getPageURL()
         })
+      } else {
+        const { message, lineno, colno, error, filename: url } = e
+        lazyReportCache({
+          msg: message,
+          line: lineno,
+          column: colno,
+          error: error.stack,
+          subType: "js",
+          pageURL: url,
+          type: "error",
+          startTime: performance.now()
+        })
       }
     },
     true
   )
 
   // 监听 js 错误
-  window.onerror = (msg, url, line, column, error) => {
-    lazyReportCache({
-      msg,
-      line,
-      column,
-      error: error.stack,
-      subType: "js",
-      pageURL: url,
-      type: "error",
-      startTime: performance.now()
-    })
-  }
+  // window.onerror = (msg, url, line, column, error) => {
+  //   lazyReportCache({
+  //     msg,
+  //     line,
+  //     column,
+  //     error: error.stack,
+  //     subType: "js",
+  //     pageURL: url,
+  //     type: "error",
+  //     startTime: performance.now()
+  //   })
+  // }
 
   // 监听 promise 错误 缺点是获取不到列数据
   window.addEventListener("unhandledrejection", (e) => {


### PR DESCRIPTION
问题：监听资源加载失败错误和监听js错误写了两个监听函数
原因：使用 window.addEventListener(”error",callback, true)同样可以监控到js错误，故不需要对js错误再写一个监听函数
解决方案：将监听js错误的函数合并到监听资源加载失败错误的函数中
具体修改如下：
     `


      window.addEventListener(
      "error",
      (e) => {
       const target = e.target
      if (!target) return

      if (target.src || target.href) {
        const url = target.src || target.href
        lazyReportCache({
          url,
          type: "error",
          subType: "resource",
          startTime: e.timeStamp,
          html: target.outerHTML,
          resourceType: target.tagName,
          paths: e.path.map((item) => item.tagName).filter(Boolean),
          pageURL: getPageURL()
        })
      } 
     +else {
       + const { message, lineno, colno, error, filename: url } = e
       + lazyReportCache({
      +    msg: message,
       +   line: lineno,
       +   column: colno,
       +  error: error.stack,
       +   subType: "js",
       +   pageURL: url,
        +  type: "error",
        +  startTime: performance.now()
      +  })
     + }
    +},
    true
  )
`
